### PR TITLE
Add pandoc to support export

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ENV LANG en_US.utf8
 
 ## install gitit
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends mime-support git gitit \
+    && apt-get install -y --no-install-recommends mime-support git gitit pandoc \
     && rm -rf /var/lib/apt/lists/*
 
 VOLUME ["/data"]


### PR DESCRIPTION
Hey, I notice you cannot enable gitit export function without pandoc installed. So I edited Dockerfile, please take a look, thanks!
